### PR TITLE
Msg

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ http {
     upstream docker {
         server 127.0.0.1:2376;
     }
-    
+
     upstream swarm {
         server 127.0.0.1:3376;
     }
@@ -63,11 +63,6 @@ http {
             proxy_set_header   Host $host;
             proxy_set_header   X-Forwarded-Host $server_name;
             proxy_set_header   X-Forwarded-Proto $scheme;
-        }
-
-        error_page   500 502 503 504  /50x.json;
-        location = /50x.json {
-            root   /usr/share/nginx/json;
         }
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -35,6 +35,7 @@ http {
 
         location ~ /docker/(?<section>.*) {
             proxy_pass http://docker/$section$is_args$args;
+            proxy_read_timeout 300;
             proxy_redirect     off;
             proxy_set_header   Host $host;
             proxy_set_header   X-Forwarded-Host $server_name;
@@ -43,6 +44,7 @@ http {
 
         location ~ /swarm/(?<section>.*) {
             proxy_pass http://swarm/$section$is_args$args;
+            proxy_read_timeout 300;
             proxy_redirect     off;
             proxy_set_header   Host $host;
             proxy_set_header   X-Forwarded-Host $server_name;


### PR DESCRIPTION
There are 2 issues:
- We increased the socket timeout for docker but nginx will terminate it anyway after 60 secs.
- We have no idea about the real error message, because we hide it. Removing that segment will fallback to the default error page which shows some information, but in html form instead of json (doesn't make much difference you have to parse it anyway)

@martonsereg please take a look
